### PR TITLE
feature: phase 1

### DIFF
--- a/docs/privacy-app.html
+++ b/docs/privacy-app.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — OpenClient LLM</title>
+  <meta name="description" content="Privacy Policy for OpenClient LLM, a native Apple client for LiteLLM.">
+  <link rel="icon" type="image/png" href="assets/icon_radius.png">
+  <link rel="apple-touch-icon" href="assets/icon_radius.png">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+
+<body>
+  <div class="container legal">
+    <h1>Privacy Policy</h1>
+    <p class="legal-updated">Last updated: March 30, 2026</p>
+
+    <div class="legal-content">
+      <h2>Summary</h2>
+      <p>OpenClient LLM does <strong>not collect, store, transmit, or share any personal data</strong>. The app runs
+        entirely on your device and communicates only with the server you configure.</p>
+
+      <h2>No Developer Backend</h2>
+      <p>OpenClient LLM has no developer-operated server, backend, analytics service, or cloud infrastructure of any
+        kind. There is no telemetry, no crash reporting, and no usage tracking. The developer never receives any data
+        from your use of the app.</p>
+
+      <h2>Local-Only Architecture</h2>
+      <p>All app data — including your settings, conversation history, and preferences — is stored locally on your
+        device. Nothing leaves your device except the requests you explicitly send to the LiteLLM server you configure.
+      </p>
+
+      <h2>Server Communication</h2>
+      <p>The app connects exclusively to the LiteLLM proxy server URL that you provide. All network requests are sent
+        directly from your device to your server. The developer has no access to, knowledge of, or involvement in this
+        communication.</p>
+
+      <h2>API Keys &amp; Credentials</h2>
+      <p>API keys are configured on your self-hosted LiteLLM server, not stored in the App. The management of API keys,
+        their associated costs, and the terms of service of any LLM provider (OpenAI, Anthropic, Ollama, etc.) are
+        entirely your responsibility as the server operator. OpenClient LLM and its developer are not affiliated with
+        any LLM provider.</p>
+
+      <h2>Third-Party Services</h2>
+      <p>The app does not integrate any third-party SDKs, analytics frameworks, advertising networks, or tracking
+        services. The only external dependency is the LiteLLM server you choose to connect to.</p>
+
+      <h2>Open Source &amp; Auditable</h2>
+      <p>OpenClient LLM is fully open source under the Apache 2.0 license. You can inspect, audit, and verify every
+        line of code in the <a href="https://github.com/ArtCC/openclient-llm">GitHub repository</a>. This transparency
+        ensures you can confirm that no data collection exists.</p>
+
+      <h2>Children's Privacy</h2>
+      <p>The app does not knowingly collect any information from anyone, including children under 13. Since no data is
+        collected at all, there is no risk of collecting children's data.</p>
+
+      <h2>Changes to This Policy</h2>
+      <p>If this policy is updated, the changes will be published on this page with an updated revision date. Since the
+        app collects no data, meaningful changes are unlikely.</p>
+
+      <h2>Contact</h2>
+      <p>If you have questions about this policy, you can open an issue on the <a
+          href="https://github.com/ArtCC/openclient-llm/issues">GitHub repository</a>.</p>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/docs/terms-app.html
+++ b/docs/terms-app.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service — OpenClient LLM</title>
+  <meta name="description" content="Terms of Service for OpenClient LLM, a native Apple client for LiteLLM.">
+  <link rel="icon" type="image/png" href="assets/icon_radius.png">
+  <link rel="apple-touch-icon" href="assets/icon_radius.png">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+
+<body>
+  <div class="container legal">
+    <h1>Terms of Service</h1>
+    <p class="legal-updated">Last updated: March 30, 2026</p>
+
+    <div class="legal-content">
+      <h2>Acceptance</h2>
+      <p>By downloading, installing, or using OpenClient LLM ("the App"), you agree to these terms. If you do not agree,
+        do not use the App.</p>
+
+      <h2>What the App Does</h2>
+      <p>OpenClient LLM is a native Apple client that connects to a <a href="https://docs.litellm.ai/"
+          style="color: var(--accent); text-decoration: none;">LiteLLM</a> proxy server you provide. It sends your
+        messages to that server and displays the responses. The App does not host, operate, or control any LLM server or
+        AI model.</p>
+
+      <h2>Your Responsibilities</h2>
+      <ul>
+        <li><strong>Server &amp; infrastructure:</strong> You are responsible for setting up, maintaining, and securing
+          your own LiteLLM server and any upstream LLM providers it connects to.</li>
+        <li><strong>API keys &amp; costs:</strong> API keys are configured on your self-hosted LiteLLM server. Any
+          costs incurred through LLM providers (OpenAI, Anthropic, Groq, etc.) are entirely your responsibility as the
+          server operator. The developer of OpenClient LLM has no involvement in, or liability for, charges from
+          third-party services.</li>
+        <li><strong>Content:</strong> You are solely responsible for the content you send through the App and the
+          responses you receive. The developer does not monitor, moderate, or store any conversations.</li>
+        <li><strong>Compliance:</strong> You agree to use the App in compliance with all applicable laws and the terms
+          of
+          service of any LLM provider you connect to.</li>
+      </ul>
+
+      <h2>Open Source License</h2>
+      <p>The App's source code is available under the <a
+          href="https://github.com/ArtCC/openclient-llm/blob/main/LICENSE"
+          style="color: var(--accent); text-decoration: none;">Apache License 2.0</a>. You may inspect, modify, and
+        redistribute the code under the terms of that license. The open-source nature of the project allows you to
+        verify all claims made in these terms and in the Privacy Policy.</p>
+
+      <h2>No Warranty</h2>
+      <p>The App is provided <strong>"as is"</strong> without warranty of any kind, express or implied, including but
+        not
+        limited to warranties of merchantability, fitness for a particular purpose, or non-infringement. The developer
+        does not guarantee that the App will be error-free, uninterrupted, or compatible with every server
+        configuration.</p>
+
+      <h2>Limitation of Liability</h2>
+      <p>To the maximum extent permitted by applicable law, the developer shall not be liable for any indirect,
+        incidental, special, consequential, or punitive damages, or any loss of data, revenue, or profits, arising from
+        your use of the App. This includes, without limitation, costs incurred through third-party API providers or data
+        loss resulting from server misconfiguration.</p>
+
+      <h2>No Affiliation</h2>
+      <p>OpenClient LLM is an independent, community-driven open-source project. It is not affiliated with, endorsed by,
+        or sponsored by LiteLLM, OpenAI, Anthropic, Ollama, Apple, or any other company mentioned in the App or its
+        documentation.</p>
+
+      <h2>Changes to These Terms</h2>
+      <p>These terms may be updated from time to time. Changes will be published on this page with an updated revision
+        date. Continued use of the App after changes constitutes acceptance of the new terms.</p>
+
+      <h2>Contact</h2>
+      <p>If you have questions about these terms, you can open an issue on the <a
+          href="https://github.com/ArtCC/openclient-llm/issues">GitHub repository</a>.</p>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/openclient-llm/Shared/Core/Utils/Constants.swift
+++ b/openclient-llm/Shared/Core/Utils/Constants.swift
@@ -18,8 +18,8 @@ enum Constants {
     // MARK: - URLs
 
     enum URLs {
-        static let privacyPolicy = URL(string: "https://www.arturocarreterocalvo.com/openclient-llm/privacy")
-        static let termsOfUse = URL(string: "https://www.arturocarreterocalvo.com/openclient-llm/terms")
+        static let privacyPolicy = URL(string: "https://www.arturocarreterocalvo.com/openclient-llm/privacy-app")
+        static let termsOfUse = URL(string: "https://www.arturocarreterocalvo.com/openclient-llm/terms-app")
         static let authorGitHub = URL(string: "https://github.com/ArtCC")
     }
 }


### PR DESCRIPTION
This pull request introduces official legal documents for the app and updates internal references to them. Specifically, it adds dedicated Privacy Policy and Terms of Service HTML files to the documentation and updates the app's constants to link to these new documents.

**Legal Documentation:**

- Added a comprehensive `privacy-app.html` file to the `docs` directory, detailing the app's privacy practices, emphasizing no data collection, local-only architecture, and open-source transparency.
- Added a `terms-app.html` file to the `docs` directory, outlining the Terms of Service, including user responsibilities, open-source licensing, disclaimers, and liability limitations.

**App URL Updates:**

- Updated the `Constants.swift` file to point `privacyPolicy` and `termsOfUse` URLs to the new `privacy-app` and `terms-app` HTML documents, ensuring the app references the latest legal content.