### PR TITLE
feature: deploy to App Store & TestFlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## [1.0.0] - 2026-04-01
+## [0.0.1] - 2026-04-02
 
 ### Added
 

--- a/openclient-llm.xcodeproj/project.pbxproj
+++ b/openclient-llm.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -562,7 +562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -617,7 +617,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -669,7 +669,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
This pull request updates the initial release version of the project from `1.0.0` to `0.0.1` to more accurately reflect its pre-release or early development status. The changes ensure that both the documentation and the Xcode project configuration are consistent with this versioning.

Versioning updates:

* Changed the version in the `CHANGELOG.md` from `1.0.0` to `0.0.1` to indicate an initial development release.
* Updated the `MARKETING_VERSION` in multiple locations within `openclient-llm.xcodeproj/project.pbxproj` from `1.0.0` to `0.0.1` to match the new versioning scheme. [[1]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL519-R519) [[2]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL565-R565) [[3]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL620-R620) [[4]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL672-R672)