### PR TITLE
feature: deploy to TestFlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,16 @@ jobs:
 
           content = open('CHANGELOG.md').read()
 
-          # Version: first ## [X.Y.Z]
-          m = re.search(r'## \[(\d+\.\d+\.\d+)\]', content)
+          # Version: first ## [X.Y.Z] or ## [X.Y.Z-suffix]
+          m = re.search(r'## \[([\d+\.\d+\.\d+][^\]]*)\]', content)
           if not m:
               print('::error::No version found in CHANGELOG.md')
               sys.exit(1)
           version = m.group(1)
 
-          # Notes: block between first ## [X.Y.Z] header and the next ## [
+          # Notes: block between first ## [X.Y.Z] or ## [X.Y.Z-suffix] header and the next ## [
           m_notes = re.search(
-              r'## \[\d+\.\d+\.\d+\][^\n]*\n(.*?)(?=\n## \[|\Z)',
+              r'## \[[^\]]+\][^\n]*\n(.*?)(?=\n## \[|\Z)',
               content, re.DOTALL
           )
           notes = m_notes.group(1).strip() if m_notes else ''


### PR DESCRIPTION
This pull request updates the regular expressions in the release workflow to better handle version numbers with optional suffixes (such as pre-release tags) when parsing the `CHANGELOG.md`. This ensures that versions like `1.2.3-beta` are correctly recognized during the release process.

**Release workflow improvements:**

* Updated the regex patterns in `.github/workflows/release.yml` to match version headers with optional suffixes (e.g., `## [1.2.3-beta]`), ensuring both the version extraction and release notes parsing work for pre-release and standard versions.