### PR TITLE
feature: deploy to TestFlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## [0.0.1-build-14] - 2026-04-04
+
+### Changed
+
+Build number
+
 ## [0.0.1-build-13] - 2026-04-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## [0.0.1-build-14] - 2026-04-04
-
-### Changed
-
-Build number
-
-## [0.0.1-build-13] - 2026-04-04
-
-### Added
-
-- Prompt Library — a curated collection of built-in system prompt templates (Coding Assistant, Translator, Summarizer, Creative Writer, Data Analyst, Email Composer) accessible directly from the System Prompt editor in any conversation
-- "Browse Library" button in `ChatSystemPromptView` — tapping it opens `PromptTemplatesView` as a sheet; selecting a template fills the system prompt field and closes the sheet automatically
-- `PromptTemplatesView` — list with two sections (Built-in / Custom); tap a template to apply it; swipe-to-delete and Edit action on custom templates; toolbar `+` button to create new ones
-- `PromptTemplateEditorView` — sheet for creating and editing custom templates with a title field and a full TextEditor for the prompt content; Save button disabled until both fields are non-empty
-- `PromptTemplate` model — `Identifiable`, `Equatable`, `Codable`, `Sendable`; `isBuiltIn` flag distinguishes system templates from user-created ones
-- `PromptTemplateRepository` — persists custom templates as individual JSON files in `DocumentDirectory/PromptTemplates/`; built-in templates are hardcoded with stable UUIDs and never written to disk
-- `LoadPromptTemplatesUseCase`, `SavePromptTemplateUseCase`, `DeletePromptTemplateUseCase` — single-responsibility use cases for the prompt library feature
-- `PromptTemplatesViewModel` — Event/State ViewModel coordinating load, save, and delete; built-in templates cannot be deleted (guard in `deleteTemplate`)
-- `MockPromptTemplateRepository`, `MockLoadPromptTemplatesUseCase`, `MockSavePromptTemplateUseCase`, `MockDeletePromptTemplateUseCase` test doubles
-- 11 unit tests in `PromptTemplatesViewModelTests` covering init state, load success/failure, create, edit (preserving id and createdAt), save failure, delete custom, guard against deleting built-ins, and delete failure
-
-## [0.0.1-build-12] - 2026-04-04
+## [1.0.0-build-15] - 2026-04-04
 
 ### Added
 
@@ -95,6 +74,16 @@ Build number
 - Settings navigation buttons simplified to plain `Label` on macOS — chevron icon and explicit `.buttonStyle(.bordered)` modifiers removed
 - Assistant message text blocks rendered using `interpretedSyntax: .inlineOnlyPreservingWhitespace` instead of `.full` — fixes all newlines and paragraph breaks being silently collapsed into spaces or removed, causing every response to appear as a single unformatted block of text regardless of model or provider
 - Normalization regex (`\n` → `\n\n`) removed from `textBlockView` as it was redundant and broke adjacent list items with the new rendering option
+- Prompt Library — a curated collection of built-in system prompt templates (Coding Assistant, Translator, Summarizer, Creative Writer, Data Analyst, Email Composer) accessible directly from the System Prompt editor in any conversation
+- "Browse Library" button in `ChatSystemPromptView` — tapping it opens `PromptTemplatesView` as a sheet; selecting a template fills the system prompt field and closes the sheet automatically
+- `PromptTemplatesView` — list with two sections (Built-in / Custom); tap a template to apply it; swipe-to-delete and Edit action on custom templates; toolbar `+` button to create new ones
+- `PromptTemplateEditorView` — sheet for creating and editing custom templates with a title field and a full TextEditor for the prompt content; Save button disabled until both fields are non-empty
+- `PromptTemplate` model — `Identifiable`, `Equatable`, `Codable`, `Sendable`; `isBuiltIn` flag distinguishes system templates from user-created ones
+- `PromptTemplateRepository` — persists custom templates as individual JSON files in `DocumentDirectory/PromptTemplates/`; built-in templates are hardcoded with stable UUIDs and never written to disk
+- `LoadPromptTemplatesUseCase`, `SavePromptTemplateUseCase`, `DeletePromptTemplateUseCase` — single-responsibility use cases for the prompt library feature
+- `PromptTemplatesViewModel` — Event/State ViewModel coordinating load, save, and delete; built-in templates cannot be deleted (guard in `deleteTemplate`)
+- `MockPromptTemplateRepository`, `MockLoadPromptTemplatesUseCase`, `MockSavePromptTemplateUseCase`, `MockDeletePromptTemplateUseCase` test doubles
+- 11 unit tests in `PromptTemplatesViewModelTests` covering init state, load success/failure, create, edit (preserving id and createdAt), save failure, delete custom, guard against deleting built-ins, and delete failure
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to report issues, propose features, and submit pull requests.
 
+You can also suggest features and report bugs directly from within the app — go to **Settings** and use the built-in feedback option powered by [Votice](https://github.com/ArtCC/votice-sdk), another open source project by the same author.
+
 ## Author
 
 **Arturo Carretero Calvo**

--- a/openclient-llm.xcodeproj/project.pbxproj
+++ b/openclient-llm.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -563,7 +563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -619,7 +619,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = OpenClient;
 				REGISTER_APP_GROUPS = YES;
@@ -673,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = OpenClient;
 				REGISTER_APP_GROUPS = YES;
@@ -697,7 +697,7 @@
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm-test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -719,7 +719,7 @@
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm-test";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/openclient-llm.xcodeproj/project.pbxproj
+++ b/openclient-llm.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -563,7 +563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -619,7 +619,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = OpenClient;
 				REGISTER_APP_GROUPS = YES;
@@ -673,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.artcc.openclient-llm";
 				PRODUCT_NAME = OpenClient;
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
This pull request updates the project versioning to reflect a new build and aligns the marketing version across the project files. The main changes are related to version and build number management.

Version and build number updates:

* Updated the `CHANGELOG.md` to add a new entry for build 14 (`0.0.1-build-14`) with a note about the build number change.
* Changed the `MARKETING_VERSION` from `0.0.2` to `0.0.1` in multiple targets within the `openclient-llm.xcodeproj/project.pbxproj` file to ensure consistency across the project. [[1]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL519-R519) [[2]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL566-R566) [[3]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL622-R622) [[4]](diffhunk://#diff-ec4cb822b3e7de48398cd518b85f64e3ca6f8dfc49386e37e58ccd376060adfaL676-R676)