### PR TITLE
feature: deploy to App Store

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -141,7 +141,14 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             PROVISIONING_PROFILE_SPECIFIER=OpenClient \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
-            2>&1 | xcpretty && exit ${PIPESTATUS[0]}
+            2>&1 | tee xcodebuild.log | xcpretty
+          RESULT=${PIPESTATUS[0]}
+          if [ $RESULT -ne 0 ]; then
+            echo "::group::xcodebuild raw output (last 300 lines)"
+            tail -300 xcodebuild.log
+            echo "::endgroup::"
+            exit $RESULT
+          fi
 
       - name: Export archive
         run: |

--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -3,6 +3,7 @@ name: macOS DMG
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: macos-dmg-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## [1.1.1-build-21] - 2026-04-13
+## [1.1.1-build-23] - 2026-04-13
 
 ### Added
 


### PR DESCRIPTION
This pull request makes improvements to the macOS DMG GitHub Actions workflow and updates the project version in the changelog. The workflow changes focus on better manual triggering and enhanced error reporting for the build process.

Workflow enhancements:

* Added support for manually triggering the `macOS DMG` workflow using `workflow_dispatch`, allowing users to run the workflow on demand.
* Improved error handling in the Xcode build step: the script now logs the raw `xcodebuild` output to a file, displays the last 300 lines if the build fails, and exits with the correct status code. This makes debugging build failures easier.

Changelog update:

* Updated the version in `CHANGELOG.md` from `1.1.1-build-21` to `1.1.1-build-23` to reflect the latest changes.