### PR TITLE
feature: deploy to App Store

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -140,6 +140,7 @@ jobs:
             -archivePath "$RUNNER_TEMP/openclient-llm.xcarchive" \
             DEVELOPMENT_TEAM=Q4X55987WE \
             CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
             PROVISIONING_PROFILE_SPECIFIER=OpenClient \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
             2>&1 | tee xcodebuild.log | xcpretty


### PR DESCRIPTION
This pull request makes a minor update to the macOS DMG build workflow by specifying the code signing identity for Xcode builds.

* Build process configuration:
  * Added the `CODE_SIGN_IDENTITY="Developer ID Application"` parameter to the Xcode build step in `.github/workflows/macos-dmg.yml` to explicitly set the code signing identity.