### PR TITLE
feature: deploy to App Store & TestFlight

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -143,14 +143,7 @@ jobs:
             CODE_SIGN_IDENTITY="Developer ID Application" \
             PROVISIONING_PROFILE_SPECIFIER=OpenClient \
             OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
-            2>&1 | tee xcodebuild.log | xcpretty
-          RESULT=${PIPESTATUS[0]}
-          if [ $RESULT -ne 0 ]; then
-            echo "::group::xcodebuild raw output (last 300 lines)"
-            tail -300 xcodebuild.log
-            echo "::endgroup::"
-            exit $RESULT
-          fi
+            2>&1 | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Export archive
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## [1.1.1-build-23] - 2026-04-13
+## [1.1.1-build-25] - 2026-04-13
 
 ### Added
 


### PR DESCRIPTION
This pull request contains a minor update to the build workflow and documentation. The most significant change is a simplification of the macOS build script, along with an update to the version number in the changelog.

Build process improvements:

* Simplified the error handling in the macOS build workflow (`.github/workflows/macos-dmg.yml`) by removing the separate logging and tailing of `xcodebuild.log`, and instead directly exiting with the correct status after running `xcpretty`.

Documentation updates:

* Updated the version number in `CHANGELOG.md` from `1.1.1-build-23` to `1.1.1-build-25`.