### PR TITLE
feature: optimization and bug fixes

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,52 @@
+name: Beta
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: beta-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  beta:
+    name: Prepare Beta
+    runs-on: macos-26
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract version and release notes
+        id: changelog
+        run: |
+          python3 - << 'PYEOF'
+          import re, sys
+
+          content = open('CHANGELOG.md').read()
+
+          # Version: first ## [X.Y.Z] or ## [X.Y.Z-suffix]
+          m = re.search(r'## \[([\d+\.\d+\.\d+][^\]]*)\]', content)
+          if not m:
+              print('::error::No version found in CHANGELOG.md')
+              sys.exit(1)
+          version = m.group(1)
+
+          # Notes: block between first ## [X.Y.Z] or ## [X.Y.Z-suffix] header and the next ## [
+          m_notes = re.search(
+              r'## \[[^\]]+\][^\n]*\n(.*?)(?=\n## \[|\Z)',
+              content, re.DOTALL
+          )
+          notes = m_notes.group(1).strip() if m_notes else ''
+
+          with open('RELEASE_VERSION', 'w') as f:
+              f.write(version)
+          with open('RELEASE_NOTES.md', 'w') as f:
+              f.write(notes)
+
+          print(f'Version: {version}')
+          PYEOF
+          echo "version=$(cat RELEASE_VERSION)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for guideli
 - `CloudSyncManager` copies attachment files to the iCloud Documents container alongside conversation JSON; deletion of a conversation or all data also removes the corresponding attachment folders from iCloud
 - `LaunchViewModel` runs `AttachmentMigrationUseCase` at startup before onboarding check
 
+### Fixed
+
+- Chat scroll system rewritten: replaced dual-API conflict (`ScrollViewReader` + `.scrollPosition`) with a single `ScrollPosition` instance, eliminating white-screen flashes and erratic jumps caused by iOS reconciling two competing scroll authorities
+- Auto-scroll during streaming now throttled to at most one update every 80 ms (down from ~50+ per second), preventing layout thrashing and mid-stream blank frames
+- `onChange(of: messages.count)` no longer forces scroll-to-bottom when the user has scrolled up to read previous messages — scroll is only triggered when the user is already near the bottom
+- Loading a conversation no longer produces a double-scroll bounce; a single `.task(id: conversation?.id)` trigger replaced the previous `scrollToBottomTrigger` toggle + `.task` race condition
+- Keyboard-show handler migrated from `DispatchQueue.main.asyncAfter` to `Task { @MainActor in }`, making it safe within Swift Concurrency's structured task lifecycle
+- `MarkdownParser.parse()` result cached in `@State` on `MessageBubbleView` and updated only when `message.content` changes, removing the repeated O(n²) re-parse on every SwiftUI render pass during streaming
+
 ## [1.1.1-build-25] - 2026-04-13
 
 ### Added

--- a/openclient-llm/Shared/Features/Chat/ViewModels/ChatViewModel.swift
+++ b/openclient-llm/Shared/Features/Chat/ViewModels/ChatViewModel.swift
@@ -64,7 +64,6 @@ final class ChatViewModel {
         var recordingDuration: TimeInterval = 0
         var isTranscribing: Bool = false
         var showTokenUsage: Bool = true
-        var scrollToBottomTrigger: Bool = false
         var ttsModelId: String?
         var transcriptionModelId: String?
         var exportedData: Data?
@@ -284,9 +283,6 @@ private extension ChatViewModel {
         loadedState.pendingAttachments = []
         loadedState.inputText = ""
         loadedState.errorMessage = nil
-        if !conversation.messages.isEmpty {
-            loadedState.scrollToBottomTrigger.toggle()
-        }
         state = .loaded(loadedState)
     }
 

--- a/openclient-llm/Shared/Features/Chat/Views/ChatView.swift
+++ b/openclient-llm/Shared/Features/Chat/Views/ChatView.swift
@@ -19,7 +19,8 @@ struct ChatView: View {
     @State private var shouldAutoScroll: Bool = true
     @State private var isNearBottom: Bool = true
     @State private var isNearTop: Bool = true
-    @State private var scrollPosition = ScrollPosition(idType: String.self)
+    @State private var scrollPosition = ScrollPosition(idType: UUID.self)
+    @State private var isScrollThrottled: Bool = false
     @State private var showSystemPromptSheet: Bool = false
     @State private var showModelParametersSheet: Bool = false
     @State private var showFavouritesSheet: Bool = false
@@ -266,35 +267,32 @@ private extension ChatView {
     func messagesScrollView(
         _ loadedState: ChatViewModel.LoadedState
     ) -> some View {
-        ScrollViewReader { proxy in
-            scrollContent(loadedState, proxy: proxy)
-                .overlay(alignment: .topTrailing) {
-                    if !isNearTop && !loadedState.messages.isEmpty {
-                        scrollAnchorButton(isTop: true) {
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                scrollPosition.scrollTo(edge: .top)
-                            }
+        scrollContent(loadedState)
+            .overlay(alignment: .topTrailing) {
+                if !isNearTop && !loadedState.messages.isEmpty {
+                    scrollAnchorButton(isTop: true) {
+                        withAnimation(.easeInOut(duration: 0.35)) {
+                            scrollPosition.scrollTo(edge: .top)
                         }
                     }
                 }
-                .overlay(alignment: .bottomTrailing) {
-                    if !isNearBottom && !loadedState.messages.isEmpty {
-                        scrollAnchorButton(isTop: false) {
-                            withAnimation(.easeInOut(duration: 0.35)) {
-                                scrollPosition.scrollTo(edge: .bottom)
-                            }
-                            shouldAutoScroll = true
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if !isNearBottom && !loadedState.messages.isEmpty {
+                    scrollAnchorButton(isTop: false) {
+                        withAnimation(.easeInOut(duration: 0.35)) {
+                            scrollPosition.scrollTo(edge: .bottom)
                         }
+                        shouldAutoScroll = true
                     }
                 }
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isNearTop)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isNearBottom)
-        }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isNearTop)
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isNearBottom)
     }
 
     func scrollContent(
-        _ loadedState: ChatViewModel.LoadedState,
-        proxy: ScrollViewProxy
+        _ loadedState: ChatViewModel.LoadedState
     ) -> some View {
         scrollViewContent(loadedState)
             .onScrollGeometryChange(for: Bool.self) {
@@ -310,42 +308,14 @@ private extension ChatView {
                     shouldAutoScroll = isNearBottom
                 }
             }
-            .onChange(of: loadedState.messages.count) {
-                shouldAutoScroll = true
-                proxy.scrollTo("scroll-bottom")
-            }
-            .onChange(of: loadedState.messages.last?.content) {
-                guard shouldAutoScroll else { return }
-                proxy.scrollTo("scroll-bottom")
-            }
-            .onChange(of: loadedState.scrollToBottomTrigger) {
-                proxy.scrollTo("scroll-bottom")
-            }
-            .onChange(of: scrollToMessageId) { _, newId in
-                guard let id = newId else { return }
-                withAnimation(.easeInOut(duration: 0.35)) { proxy.scrollTo(id, anchor: .center) }
-                scrollToMessageId = nil
-            }
-            .task(id: loadedState.messages.isEmpty) {
-                guard !loadedState.messages.isEmpty else { return }
-                try? await Task.sleep(for: .milliseconds(120))
-                withAnimation(.easeInOut(duration: 0.3)) { proxy.scrollTo("scroll-bottom") }
-            }
-#if os(iOS)
-            .onReceive(
-                NotificationCenter.default.publisher(
-                    for: UIResponder.keyboardWillShowNotification
-                )
-            ) { notification in
-                let duration = notification.userInfo?[
-                    UIResponder.keyboardAnimationDurationUserInfoKey
-                ] as? Double ?? 0.25
-                DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-                    proxy.scrollTo("scroll-bottom")
-                    shouldAutoScroll = true
-                }
-            }
-#endif
+            .modifier(ScrollTriggerModifier(
+                loadedState: loadedState,
+                scrollPosition: $scrollPosition,
+                isScrollThrottled: $isScrollThrottled,
+                scrollToMessageId: $scrollToMessageId,
+                shouldAutoScroll: $shouldAutoScroll,
+                isNearBottom: isNearBottom
+            ))
     }
 
     func scrollViewContent(
@@ -374,9 +344,6 @@ private extension ChatView {
         _ loadedState: ChatViewModel.LoadedState
     ) -> some View {
         LazyVStack(spacing: 16) {
-            Color.clear
-                .frame(height: 1)
-                .id("scroll-top")
             ForEach(loadedState.messages) { message in
                 let isLast = message.id == loadedState.messages.last?.id
                 MessageBubbleView(
@@ -409,9 +376,6 @@ private extension ChatView {
                 .id(message.id)
                 .transition(.opacity)
             }
-            Color.clear
-                .frame(height: 1)
-                .id("scroll-bottom")
         }
         .padding(.horizontal, 16)
         .frame(maxWidth: 760)
@@ -465,6 +429,64 @@ private extension ChatView {
         .transition(.scale(scale: 0.8).combined(with: .opacity))
     }
 
+}
+
+private struct ScrollTriggerModifier: ViewModifier {
+    let loadedState: ChatViewModel.LoadedState
+    @Binding var scrollPosition: ScrollPosition
+    @Binding var isScrollThrottled: Bool
+    @Binding var scrollToMessageId: UUID?
+    @Binding var shouldAutoScroll: Bool
+    let isNearBottom: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: loadedState.messages.count) {
+                guard isNearBottom else { return }
+                shouldAutoScroll = true
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    scrollPosition.scrollTo(edge: .bottom)
+                }
+            }
+            .onChange(of: loadedState.messages.last?.content) {
+                guard shouldAutoScroll, !isScrollThrottled else { return }
+                isScrollThrottled = true
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(80))
+                    scrollPosition.scrollTo(edge: .bottom)
+                    isScrollThrottled = false
+                }
+            }
+            .onChange(of: scrollToMessageId) { _, newId in
+                guard let id = newId else { return }
+                withAnimation(.easeInOut(duration: 0.35)) {
+                    scrollPosition.scrollTo(id: id)
+                }
+                scrollToMessageId = nil
+            }
+            .task(id: loadedState.conversation?.id) {
+                guard !loadedState.messages.isEmpty else { return }
+                try? await Task.sleep(for: .milliseconds(120))
+                guard !Task.isCancelled else { return }
+                scrollPosition.scrollTo(edge: .bottom)
+            }
+#if os(iOS)
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: UIResponder.keyboardWillShowNotification
+                )
+            ) { notification in
+                let duration = notification.userInfo?[
+                    UIResponder.keyboardAnimationDurationUserInfoKey
+                ] as? Double ?? 0.25
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(duration))
+                    scrollPosition.scrollTo(edge: .bottom)
+                    shouldAutoScroll = true
+                }
+            }
+#endif
+    }
 }
 
 #Preview {

--- a/openclient-llm/Shared/Features/Chat/Views/MessageBubbleView.swift
+++ b/openclient-llm/Shared/Features/Chat/Views/MessageBubbleView.swift
@@ -30,6 +30,7 @@ struct MessageBubbleView: View {
     var onFavouriteTapped: (() -> Void)?
     @State private var cursorVisible: Bool = false
     @State private var isThinkingExpanded: Bool = true
+    @State private var parsedBlocks: [MessageBlock] = []
 
     // MARK: - View
 
@@ -127,6 +128,12 @@ private extension MessageBubbleView {
             }
 
             Spacer(minLength: 40)
+        }
+        .onAppear {
+            parsedBlocks = MarkdownParser.parse(message.content)
+        }
+        .onChange(of: message.content) {
+            parsedBlocks = MarkdownParser.parse(message.content)
         }
         .task(id: isStreaming) {
             guard isStreaming else {
@@ -260,11 +267,9 @@ private extension MessageBubbleView {
     // MARK: - Blocks
 
     var blocksView: some View {
-        let blocks = MarkdownParser.parse(message.content)
-
-        return VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { index, block in
-                let isLastBlock = index == blocks.count - 1
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(parsedBlocks.enumerated()), id: \.offset) { index, block in
+                let isLastBlock = index == parsedBlocks.count - 1
 
                 switch block {
                 case .text(let content):


### PR DESCRIPTION
This pull request introduces major improvements to the chat scroll system, addresses several performance and UX issues, and updates CI/CD workflows to use the `develop` branch. The most significant changes include a complete rewrite of the chat scroll logic for reliability and smoothness, caching of markdown parsing to optimize rendering, and workflow enhancements for beta releases and CI.

**Chat Scroll System Improvements**
- Rewrote the chat scroll system to eliminate the dual-API conflict between `ScrollViewReader` and `.scrollPosition`, consolidating to a single `ScrollPosition` instance. This resolves white-screen flashes and erratic jumps caused by iOS reconciling two competing scroll authorities. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452L269-R270) [[3]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452L293-R295) [[4]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452L313-R318) [[5]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452L377-L379) [[6]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452L412-L414) [[7]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452R434-R491) [[8]](diffhunk://#diff-2ee88ba671fe7a11e660bbd58285289409f72a1c5d157c431384e75d1da75fd9L67) [[9]](diffhunk://#diff-2ee88ba671fe7a11e660bbd58285289409f72a1c5d157c431384e75d1da75fd9L287-L289)
- Introduced a `ScrollTriggerModifier` to handle all scroll-related triggers in a unified, throttled, and platform-safe way, including keyboard show events and auto-scroll during streaming.

**Performance and UX Fixes**
- Throttled auto-scroll during streaming to at most one update every 80ms (down from ~50+ per second), preventing layout thrashing and mid-stream blank frames. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452R434-R491)
- Changed scroll-to-bottom behavior: now only triggers if the user is already near the bottom, so users reading previous messages are not interrupted. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452R434-R491)
- Fixed double-scroll bounce on conversation load by using `.task(id: conversation?.id)` instead of a toggle/race condition. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452R434-R491)
- Migrated the keyboard-show handler to Swift Concurrency (`Task { @MainActor in }`) for safety and reliability. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-711e393b69086786d9a6e4ac4b464bf22cf443b929f505f2b86a6ad9b5c14452R434-R491)

**Rendering Optimization**
- Cached the result of `MarkdownParser.parse()` in `@State` within `MessageBubbleView`, updating only when `message.content` changes. This removes repeated O(n²) parsing on every SwiftUI render during streaming, significantly improving performance. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24-R32) [[2]](diffhunk://#diff-ca220298c285013775568b1880b818bc740a08d4d24f617f24efa0fa348ad71dR33) [[3]](diffhunk://#diff-ca220298c285013775568b1880b818bc740a08d4d24f617f24efa0fa348ad71dR132-R137) [[4]](diffhunk://#diff-ca220298c285013775568b1880b818bc740a08d4d24f617f24efa0fa348ad71dL263-R272)

**Workflow and CI/CD Updates**
- Added a new GitHub Actions workflow `.github/workflows/beta.yml` to automate beta release preparations, including extracting version and release notes from `CHANGELOG.md`.
- Updated CI workflow to run on the `develop` branch instead of `main`, aligning with the new branch strategy.

**Changelog**
- Documented all of the above fixes and improvements under a new "Fixed" section in `CHANGELOG.md`.